### PR TITLE
fix(auth): secure demo import handlers

### DIFF
--- a/inc/class/class-importer.php
+++ b/inc/class/class-importer.php
@@ -38,6 +38,22 @@ if ( ! class_exists( 'Travelfic_Template_Importer' ) ) {
 			add_action( 'wp_head', array( $this, 'prepare_travelfic_elementor_background_images' ));
 		}
 
+		/**
+		 * Verify an AJAX demo-import request.
+		 */
+		private function verify_import_request() {
+			check_ajax_referer( 'updates', '_ajax_nonce' );
+
+			if ( ! current_user_can( 'manage_options' ) ) {
+				wp_send_json_error(
+					array(
+						'message' => esc_html__( 'You are not allowed to import demo content.', 'travelfic-toolkit' ),
+					),
+					403
+				);
+			}
+		}
+
 		public function switch_to_travelfic_theme() {
 			check_ajax_referer('updates', '_ajax_nonce');
 			if ( current_user_can( 'switch_themes' ) && current_user_can( 'install_themes' ) ) {
@@ -204,11 +220,7 @@ if ( ! class_exists( 'Travelfic_Template_Importer' ) ) {
 		 * @since 1.0.0
 		 */
 		public function prepare_bricks_template_import() {
-			check_ajax_referer( 'updates', '_ajax_nonce' );
-
-			if ( ! current_user_can( 'manage_options' ) ) {
-				wp_send_json_error( 'Not allowed.' );
-			}
+			$this->verify_import_request();
 
 			$template_key = ! empty( $_POST['template_version'] ) ? sanitize_key( $_POST['template_version'] ) : 1;
 			$base_url     = 'https://api.themefic.com/tourfic/demos/v' . $template_key . '/';
@@ -482,7 +494,7 @@ if ( ! class_exists( 'Travelfic_Template_Importer' ) ) {
 		 * Tourfic Global Settings
 		 */
 		public function prepare_travelfic_global_settings() {
-            check_ajax_referer('updates', '_ajax_nonce');
+			$this->verify_import_request();
             $template_key = !empty($_POST['template_version']) ? sanitize_key( $_POST['template_version'] ) : 1;
             $demo_data_url = 'https://api.themefic.com/tourfic/demos/v'.$template_key.'/settings-v2.json';
             $settings_files = wp_remote_get( $demo_data_url );
@@ -506,7 +518,7 @@ if ( ! class_exists( 'Travelfic_Template_Importer' ) ) {
 		 * Tourfic Customizer Importer Settings
 		 */
 		public function prepare_travelfic_customizer_settings() {
-            check_ajax_referer('updates', '_ajax_nonce');
+			$this->verify_import_request();
             remove_theme_mods();
             $prefix = 'travelfic_customizer_settings_';
             $template_key = !empty($_POST['template_version']) ? sanitize_key( $_POST['template_version'] ) : 1;
@@ -625,7 +637,7 @@ if ( ! class_exists( 'Travelfic_Template_Importer' ) ) {
 		 */
 		public function prepare_travelfic_pages_imports() {
 
-            check_ajax_referer('updates', '_ajax_nonce');
+			$this->verify_import_request();
             $template_key = !empty($_POST['template_version']) ? sanitize_key( $_POST['template_version'] ) : 1;
             $builder = !empty($_POST['builder']) ? sanitize_key( $_POST['builder'] ) : 'elementor';
 
@@ -1031,7 +1043,7 @@ if ( ! class_exists( 'Travelfic_Template_Importer' ) ) {
 		 * Tourfic Menu importer Settings
 		 */
 		public function prepare_travelfic_menus_imports() {
-            check_ajax_referer('updates', '_ajax_nonce');
+			$this->verify_import_request();
             $template_key = !empty($_POST['template_version']) ? sanitize_key( $_POST['template_version'] ) : 1;
             $builder = !empty($_POST['builder']) ? sanitize_key( $_POST['builder'] ) : 'elementor';
 
@@ -1157,7 +1169,7 @@ if ( ! class_exists( 'Travelfic_Template_Importer' ) ) {
 		 * Tourfic Widget importer Settings
 		 */
 		public function prepare_travelfic_widgets_imports() {
-            check_ajax_referer('updates', '_ajax_nonce');
+			$this->verify_import_request();
             
             self::travelfic_toolkit_clear_widgets();
             $template_key  = !empty($_POST['template_version']) ? sanitize_key( $_POST['template_version'] ) : 1;
@@ -1309,7 +1321,7 @@ if ( ! class_exists( 'Travelfic_Template_Importer' ) ) {
 		 */
 		public function prepare_travelfic_hotel_imports() {
 
-            check_ajax_referer('updates', '_ajax_nonce');
+			$this->verify_import_request();
 
             $template_key = !empty($_POST['template_version']) ? sanitize_key( $_POST['template_version'] ) : 1;
             $hotels_post  = array(
@@ -1968,7 +1980,7 @@ if ( ! class_exists( 'Travelfic_Template_Importer' ) ) {
 		 */
 		public function prepare_travelfic_tour_imports() {
 
-            check_ajax_referer('updates', '_ajax_nonce');
+			$this->verify_import_request();
 
             $tours_post = array(
                 'post_type'      => 'tf_tours',
@@ -2301,7 +2313,7 @@ if ( ! class_exists( 'Travelfic_Template_Importer' ) ) {
 		 * Tourfic Car importer Settings
 		 */
         public function prepare_travelfic_car_imports() {
-            check_ajax_referer('updates', '_ajax_nonce');
+			$this->verify_import_request();
 
             $tours_post = array(
                 'post_type'      => 'tf_carrental',

--- a/tests/security/importer-authorization-live.php
+++ b/tests/security/importer-authorization-live.php
@@ -1,0 +1,196 @@
+<?php
+/**
+ * Live authorization checks for destructive demo-import AJAX handlers.
+ *
+ * Run from the TravelFic Toolkit plugin root:
+ * wp eval-file tests/security/importer-authorization-live.php
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	fwrite( STDERR, "This check must run inside WordPress.\n" );
+	exit( 1 );
+}
+
+if ( ! defined( 'DOING_AJAX' ) ) {
+	define( 'DOING_AJAX', true );
+}
+
+$importer_file = dirname( __DIR__, 2 ) . '/inc/class/class-importer.php';
+if ( ! class_exists( 'Travelfic_Template_Importer' ) && is_readable( $importer_file ) ) {
+	require_once $importer_file;
+}
+
+function travelfic_import_live_assert( $condition, $message ) {
+	if ( ! $condition ) {
+		fwrite( STDERR, "FAIL: {$message}\n" );
+		exit( 1 );
+	}
+}
+
+function travelfic_import_live_die_handler() {
+	return 'travelfic_import_live_throw_on_die';
+}
+
+function travelfic_import_live_throw_on_die() {
+	throw new RuntimeException( 'WordPress AJAX response completed.' );
+}
+
+function travelfic_import_live_capture_status( $status_header, $status_code ) {
+	$GLOBALS['travelfic_import_live_status'] = absint( $status_code );
+
+	return $status_header;
+}
+
+function travelfic_import_live_site_snapshot() {
+	$post_counts = array();
+	foreach ( array( 'page', 'tf_hotel', 'tf_tours', 'tf_carrental' ) as $post_type ) {
+		$post_counts[ $post_type ] = wp_count_posts( $post_type );
+	}
+
+	return md5(
+		maybe_serialize(
+			array(
+				'blogname'                   => get_option( 'blogname' ),
+				'blogdescription'            => get_option( 'blogdescription' ),
+				'show_on_front'              => get_option( 'show_on_front' ),
+				'page_on_front'              => get_option( 'page_on_front' ),
+				'page_for_posts'             => get_option( 'page_for_posts' ),
+				'permalink_structure'        => get_option( 'permalink_structure' ),
+				'sidebars_widgets'           => get_option( 'sidebars_widgets' ),
+				'tf_settings'                => get_option( 'tf_settings' ),
+				'travelfic_template_version' => get_option( 'travelfic_template_version' ),
+				'theme_mods'                 => get_option( 'theme_mods_' . get_option( 'stylesheet' ) ),
+				'post_counts'                => $post_counts,
+				'menu_count'                 => wp_count_terms(
+					array(
+						'taxonomy'   => 'nav_menu',
+						'hide_empty' => false,
+					)
+				),
+			)
+		)
+	);
+}
+
+function travelfic_import_live_registered_importer( $action ) {
+	global $wp_filter;
+
+	$hook = 'wp_ajax_' . $action;
+	if ( empty( $wp_filter[ $hook ]->callbacks ) ) {
+		return null;
+	}
+
+	foreach ( $wp_filter[ $hook ]->callbacks as $callbacks ) {
+		foreach ( $callbacks as $callback ) {
+			$function = isset( $callback['function'] ) ? $callback['function'] : null;
+			if (
+				is_array( $function )
+				&& isset( $function[0] )
+				&& $function[0] instanceof Travelfic_Template_Importer
+			) {
+				return $function[0];
+			}
+		}
+	}
+
+	return null;
+}
+
+$administrators = get_users(
+	array(
+		'role'   => 'administrator',
+		'number' => 1,
+		'fields' => 'all',
+	)
+);
+$subscribers = get_users(
+	array(
+		'role'   => 'subscriber',
+		'number' => 1,
+		'fields' => 'all',
+	)
+);
+
+if ( empty( $administrators[0] ) || empty( $subscribers[0] ) ) {
+	echo "TravelFic importer live checks skipped: administrator and Subscriber users are required.\n";
+	return;
+}
+
+$actions = array(
+	'travelfic-global-settings-import',
+	'travelfic-customizer-settings-import',
+	'travelfic-demo-hotel-import',
+	'travelfic-demo-tour-import',
+	'travelfic-demo-car-import',
+	'travelfic-demo-pages-import',
+	'travelfic-demo-widget-import',
+	'travelfic-demo-menu-import',
+);
+
+foreach ( $actions as $action ) {
+	travelfic_import_live_assert(
+		false !== has_action( 'wp_ajax_' . $action ),
+		"AJAX callback {$action} is not registered."
+	);
+}
+$importer = travelfic_import_live_registered_importer( $actions[0] );
+travelfic_import_live_assert(
+	$importer instanceof Travelfic_Template_Importer,
+	'The registered importer callback could not be inspected.'
+);
+
+add_filter( 'wp_die_ajax_handler', 'travelfic_import_live_die_handler' );
+add_filter( 'status_header', 'travelfic_import_live_capture_status', 10, 2 );
+wp_set_current_user( $subscribers[0]->ID );
+$site_snapshot = travelfic_import_live_site_snapshot();
+
+foreach ( $actions as $action ) {
+	$_POST = array(
+		'action'           => $action,
+		'_ajax_nonce'      => wp_create_nonce( 'updates' ),
+		'template_version' => '1',
+	);
+	$_REQUEST = $_POST;
+
+	$GLOBALS['travelfic_import_live_status'] = 0;
+	ob_start();
+	$completed = false;
+	try {
+		do_action( 'wp_ajax_' . $action );
+	} catch ( RuntimeException $error ) {
+		$completed = true;
+	}
+	$response = ob_get_clean();
+	$data     = json_decode( $response, true );
+
+	travelfic_import_live_assert( $completed, "Subscriber request {$action} did not terminate." );
+	travelfic_import_live_assert(
+		is_array( $data ) && false === $data['success'],
+		"Subscriber request {$action} did not return a JSON error."
+	);
+	travelfic_import_live_assert(
+		403 === $GLOBALS['travelfic_import_live_status'],
+		"Subscriber request {$action} did not return HTTP 403."
+	);
+}
+
+travelfic_import_live_assert(
+	$site_snapshot === travelfic_import_live_site_snapshot(),
+	'Denied Subscriber imports must not modify site content or settings.'
+);
+
+$method   = new ReflectionMethod( $importer, 'verify_import_request' );
+$method->setAccessible( true );
+
+wp_set_current_user( $administrators[0]->ID );
+$_POST = array( '_ajax_nonce' => wp_create_nonce( 'updates' ) );
+$_REQUEST = $_POST;
+$method->invoke( $importer );
+
+remove_filter( 'wp_die_ajax_handler', 'travelfic_import_live_die_handler' );
+remove_filter( 'status_header', 'travelfic_import_live_capture_status', 10 );
+wp_set_current_user( 0 );
+$_POST    = array();
+$_REQUEST = array();
+
+echo "TravelFic Toolkit importer live authorization checks passed.\n";

--- a/tests/security/importer-authorization-security.php
+++ b/tests/security/importer-authorization-security.php
@@ -1,0 +1,121 @@
+<?php
+/**
+ * Static authorization checks for destructive demo-import AJAX handlers.
+ *
+ * Run from the TravelFic Toolkit plugin root:
+ * php tests/security/importer-authorization-security.php
+ */
+
+$root          = dirname( __DIR__, 2 );
+$importer_file = $root . '/inc/class/class-importer.php';
+$list_file     = $root . '/inc/class/class-template-list.php';
+
+foreach ( array( $importer_file, $list_file ) as $file ) {
+	if ( ! is_readable( $file ) ) {
+		fwrite( STDERR, "Missing fixture: {$file}\n" );
+		exit( 1 );
+	}
+}
+
+function travelfic_import_security_assert( $condition, $message ) {
+	if ( ! $condition ) {
+		fwrite( STDERR, "FAIL: {$message}\n" );
+		exit( 1 );
+	}
+}
+
+function travelfic_import_security_method_body( $source, $method ) {
+	$matched = preg_match(
+		'/function\s+' . preg_quote( $method, '/' ) . '\s*\(/',
+		$source,
+		$matches,
+		PREG_OFFSET_CAPTURE
+	);
+	travelfic_import_security_assert( 1 === $matched, "Method {$method} not found." );
+
+	$offset = $matches[0][1];
+	$brace  = strpos( $source, '{', $offset );
+	travelfic_import_security_assert( false !== $brace, "Method {$method} has no body." );
+
+	$depth  = 0;
+	$length = strlen( $source );
+	for ( $index = $brace; $index < $length; $index++ ) {
+		if ( '{' === $source[ $index ] ) {
+			$depth++;
+		} elseif ( '}' === $source[ $index ] ) {
+			$depth--;
+			if ( 0 === $depth ) {
+				return substr( $source, $brace, $index - $brace + 1 );
+			}
+		}
+	}
+
+	travelfic_import_security_assert( false, "Method {$method} body is not balanced." );
+}
+
+$importer_source = file_get_contents( $importer_file );
+$list_source     = file_get_contents( $list_file );
+$handlers        = array(
+	'travelfic-global-settings-import'     => array( 'prepare_travelfic_global_settings', '$template_key' ),
+	'travelfic-customizer-settings-import' => array( 'prepare_travelfic_customizer_settings', 'remove_theme_mods' ),
+	'travelfic-demo-hotel-import'          => array( 'prepare_travelfic_hotel_imports', '$template_key' ),
+	'travelfic-demo-tour-import'           => array( 'prepare_travelfic_tour_imports', '$tours_post' ),
+	'travelfic-demo-car-import'            => array( 'prepare_travelfic_car_imports', '$tours_post' ),
+	'travelfic-demo-pages-import'          => array( 'prepare_travelfic_pages_imports', '$template_key' ),
+	'travelfic-demo-widget-import'         => array(
+		'prepare_travelfic_widgets_imports',
+		'travelfic_toolkit_clear_widgets',
+	),
+	'travelfic-demo-menu-import'           => array( 'prepare_travelfic_menus_imports', '$template_key' ),
+);
+
+travelfic_import_security_assert( 8 === count( $handlers ), 'The reported handler matrix must contain eight actions.' );
+
+$guard = travelfic_import_security_method_body( $importer_source, 'verify_import_request' );
+travelfic_import_security_assert(
+	false !== strpos( $guard, "check_ajax_referer( 'updates', '_ajax_nonce' )" ),
+	'The shared import guard must retain nonce validation.'
+);
+travelfic_import_security_assert(
+	false !== strpos( $guard, "current_user_can( 'manage_options' )" ),
+	'The shared import guard must require administrator capability.'
+);
+travelfic_import_security_assert(
+	false !== strpos( $guard, 'wp_send_json_error' ) && false !== strpos( $guard, '403' ),
+	'Unauthorized import requests must return a JSON error with HTTP 403.'
+);
+travelfic_import_security_assert(
+	false !== strpos( $list_source, "'manage_options'" ),
+	'The import guard must match the template-library screen capability.'
+);
+
+foreach ( $handlers as $action => $handler ) {
+	list( $method, $first_operation ) = $handler;
+	$registration = "add_action( 'wp_ajax_{$action}', array( \$this, '{$method}' ) )";
+
+	travelfic_import_security_assert(
+		false !== strpos( $importer_source, $registration ),
+		"AJAX action {$action} must remain registered."
+	);
+
+	$body             = travelfic_import_security_method_body( $importer_source, $method );
+	$guard_offset     = strpos( $body, '$this->verify_import_request()' );
+	$operation_offset = strpos( $body, $first_operation );
+
+	travelfic_import_security_assert(
+		false !== $guard_offset,
+		"Handler {$method} must call the shared import guard."
+	);
+	travelfic_import_security_assert(
+		false !== $operation_offset && $guard_offset < $operation_offset,
+		"Handler {$method} must authorize before processing import data."
+	);
+}
+
+$bricks_handler = travelfic_import_security_method_body( $importer_source, 'prepare_bricks_template_import' );
+travelfic_import_security_assert(
+	false !== strpos( $bricks_handler, '$this->verify_import_request()' ),
+	'The Bricks importer must use the same authorization boundary.'
+);
+
+echo "TravelFic Toolkit importer authorization regression checks passed.\n";


### PR DESCRIPTION
The eight destructive AJAX import handlers trusted the shared updates nonce without checking user capabilities.

Require manage_options before any import mutation, reuse the guard for Bricks imports, and add static/live authorization coverage. Subscribers now receive HTTP 403 while administrator imports continue.